### PR TITLE
fix: export complete release SBOM

### DIFF
--- a/.github/release-notes/v0.1.0-alpha.1.md
+++ b/.github/release-notes/v0.1.0-alpha.1.md
@@ -21,7 +21,7 @@ Requires macOS 13 or later on Apple Silicon. Intel Macs and Windows are not incl
 - Guided theme editing, local theme library, import, and export.
 - Data-only theme validation and strict archive safety limits.
 - Loopback-only managed Codex launch, safe-mode scene injection, pause, and restore.
-- SHA-256 checksums, SPDX SBOM, and GitHub build/SBOM attestations.
+- SHA-256 checksums, an SPDX 2.3 dependency SBOM exported from GitHub's dependency graph, and GitHub build/SBOM attestations.
 
 ## Verification status
 

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -84,9 +84,8 @@ jobs:
           set -euo pipefail
           source_dmg="apps/desktop/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Codex Styler_${RELEASE_VERSION}_aarch64.dmg"
           release_dir="$GITHUB_WORKSPACE/release"
-          scan_dir="$GITHUB_WORKSPACE/release-scan"
           mount_dir="$RUNNER_TEMP/codex-styler-dmg"
-          mkdir -p "$release_dir" "$scan_dir" "$mount_dir"
+          mkdir -p "$release_dir" "$mount_dir"
           cp "$source_dmg" "$release_dir/$DMG_NAME"
 
           hdiutil verify "$release_dir/$DMG_NAME"
@@ -100,21 +99,22 @@ jobs:
           test "$(plutil -extract CFBundleIdentifier raw "$app/Contents/Info.plist")" = "studio.xuhuan.codexstyler"
           codesign --verify --deep --strict --verbose=2 "$app"
           codesign -dvvv "$app" 2>&1 | grep -q "Signature=adhoc"
-          cp -R "$app" "$scan_dir/Codex Styler.app"
 
           hdiutil detach "$mount_dir"
           trap - EXIT
           (cd "$release_dir" && shasum -a 256 "$DMG_NAME" > SHA256SUMS.txt)
 
-      - name: Generate SPDX SBOM
-        uses: anchore/sbom-action@v0
-        with:
-          path: ./release-scan/Codex Styler.app
-          format: spdx-json
-          artifact-name: ${{ env.SBOM_NAME }}
-          output-file: ./release/${{ env.SBOM_NAME }}
-          upload-artifact: false
-          upload-release-assets: false
+      - name: Export and validate SPDX dependency SBOM
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/dependency-graph/sbom" \
+            --jq '.sbom' > "release/$SBOM_NAME"
+          jq -e \
+            '.spdxVersion == "SPDX-2.3" and (.packages | length) > 0 and (.relationships | length) > 0' \
+            "release/$SBOM_NAME" >/dev/null
 
       - name: Attest build provenance
         uses: actions/attest@v4
@@ -128,7 +128,7 @@ jobs:
           sbom-path: ./release/${{ env.SBOM_NAME }}
 
       - name: Retain reviewed release assets
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: codex-styler-${{ env.RELEASE_VERSION }}-macos-aarch64
           path: release/*

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -9,7 +9,7 @@ Preview releases are started by a deliberate version-tag push, not by every merg
 1. synchronize all versions and add `.github/release-notes/v<version>.md`;
 2. run `pnpm check:release-version <version>` and the normal test/audit suite;
 3. create and push an annotated `v<version>` tag that matches `v*-alpha.*`;
-4. let `preview-release.yml` produce an ad-hoc signed Apple Silicon DMG, SHA-256 checksums, SPDX SBOM, and GitHub attestations;
+4. let `preview-release.yml` produce an ad-hoc signed Apple Silicon DMG, SHA-256 checksums, an SPDX 2.3 export of GitHub's dependency graph, and GitHub attestations;
 5. inspect the generated draft release and download the assets to verify the published checksum;
 6. only then publish the draft as a GitHub Pre-release.
 


### PR DESCRIPTION
## What changed

- replaces the app-bundle-only SBOM with the repository's complete GitHub dependency-graph SPDX 2.3 export;
- validates that the SBOM contains packages and dependency relationships before attesting it;
- removes the no-longer-needed copied app bundle from the workflow;
- upgrades `actions/upload-artifact` to the current Node.js 24-based major version.

## Why

Draft release review showed that scanning only the mounted `.app` produced a 1.2 KB SBOM that did not describe the full JavaScript and Rust dependency graph. The GitHub SPDX export currently contains 1,023 packages and 1,282 relationships, so it is the honest release artifact.

## Validation

- exported the public dependency graph and validated SPDX 2.3, package count, and relationship count with the exact workflow commands;
- YAML syntax and Prettier checks pass;
- release workflow diff passes `git diff --check`.

The existing release remains a private draft and will be discarded before recreating the version tag from the corrected commit.
